### PR TITLE
Fix: newer OpenSSL don't expose strcut EVP_CIPHER_CTX

### DIFF
--- a/ldar_crypto.cpp
+++ b/ldar_crypto.cpp
@@ -23,17 +23,18 @@ AESCrypter::AESCrypter(const char* key, const char* iv): key_(key), iv_(iv) {
 }
 
 AESCrypter::~AESCrypter() {
-  EVP_CIPHER_CTX_cleanup(&ctx_);
+  EVP_CIPHER_CTX_cleanup(ctx_);
 }
 
 void AESCrypter::Init() {
-  EVP_CIPHER_CTX_init(&ctx_);
+  ctx_ = EVP_CIPHER_CTX_new();
+  EVP_CIPHER_CTX_init(ctx_);
   cryptoAlgorithm_ = EVP_aes_128_cbc();
 }
 
 int AESCrypter::BlockSize() const
 {
-  return EVP_CIPHER_CTX_block_size(&ctx_);
+  return EVP_CIPHER_CTX_block_size(ctx_);
 }
 
 
@@ -41,20 +42,20 @@ void AESCrypter::Setup(int dir)
 {
   dir_ = dir;
   if (0 == dir) {
-    EVP_EncryptInit_ex(&ctx_, cryptoAlgorithm_, 0, 0, 0);
-    EVP_CIPHER_CTX_set_key_length(&ctx_, key_.size());
-    EVP_EncryptInit_ex(&ctx_, 0, 0,
+    EVP_EncryptInit_ex(ctx_, cryptoAlgorithm_, 0, 0, 0);
+    EVP_CIPHER_CTX_set_key_length(ctx_, key_.size());
+    EVP_EncryptInit_ex(ctx_, 0, 0,
                        (const unsigned char*)(key_.data()),
                        (const unsigned char*)(iv_.data()));
   } else {
-    EVP_DecryptInit_ex(&ctx_, cryptoAlgorithm_, 0, 0, 0);
-    EVP_CIPHER_CTX_set_key_length(&ctx_, key_.size());
-    EVP_DecryptInit_ex(&ctx_, 0, 0,
+    EVP_DecryptInit_ex(ctx_, cryptoAlgorithm_, 0, 0, 0);
+    EVP_CIPHER_CTX_set_key_length(ctx_, key_.size());
+    EVP_DecryptInit_ex(ctx_, 0, 0,
                        (const unsigned char*)(key_.data()),
                        (const unsigned char*)(iv_.data()));
   }
 
-  EVP_CIPHER_CTX_set_padding(&ctx_, 1);
+  EVP_CIPHER_CTX_set_padding(ctx_, 1);
 }
 
 bool AESCrypter::Update(const std::string &in, std::string& out)
@@ -65,7 +66,7 @@ bool AESCrypter::Update(const std::string &in, std::string& out)
   out.resize(in.size()+BlockSize());
   int resultLength;
   if (0 == dir_) {
-    if (0 == EVP_EncryptUpdate(&ctx_,
+    if (0 == EVP_EncryptUpdate(ctx_,
                                (unsigned char*)out.data(),
                                &resultLength,
                                (unsigned char*)in.data(),
@@ -73,7 +74,7 @@ bool AESCrypter::Update(const std::string &in, std::string& out)
       return false;
     }
   } else {
-    if (0 == EVP_DecryptUpdate(&ctx_,
+    if (0 == EVP_DecryptUpdate(ctx_,
                                (unsigned char*)out.data(),
                                &resultLength,
                                (unsigned char*)in.data(),
@@ -90,13 +91,13 @@ bool AESCrypter::Final(std::string &out)
   out.resize(BlockSize());
   int resultLength;
   if (0 == dir_) {
-    if (0 == EVP_EncryptFinal_ex(&ctx_,
+    if (0 == EVP_EncryptFinal_ex(ctx_,
                                  (unsigned char*)out.data(),
                                  &resultLength)) {
       return false;
     }
   } else {
-    if (0 == EVP_DecryptFinal_ex(&ctx_,
+    if (0 == EVP_DecryptFinal_ex(ctx_,
                                  (unsigned char*)out.data(),
                                  &resultLength)) {
       return false;

--- a/ldar_crypto.h
+++ b/ldar_crypto.h
@@ -32,7 +32,7 @@ private:
   int dir_;
   std::string key_;
   std::string iv_;
-  EVP_CIPHER_CTX ctx_;
+  EVP_CIPHER_CTX *ctx_;
   const EVP_CIPHER *cryptoAlgorithm_;
 };
 


### PR DESCRIPTION
Code cannot compile in the new OpenSSL
[link](https://stackoverflow.com/questions/47518843/error-field-ctx-has-incomplete-type-evp-cipher-ctx)
